### PR TITLE
HelpRequest controller now has delete operation + passing jacoco and pitest 100%!

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -111,4 +111,17 @@ public class HelpRequestController extends ApiController {
 
         return helpRequest;
     }
+
+    // DELETE : deletes a single entry in the data table via ID.
+    @Operation(summary= "Delete a help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteHelpRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        helpRequestRepository.delete(helpRequest);
+        return genericMessage("HelpRequest with id %s deleted".formatted(id));
+    }
 }


### PR DESCRIPTION
HelpRequest data table now has delete CRUD operation and is passing for all jacoco + pitest coverages (100%!)

Closes #36 ! 🌟 